### PR TITLE
Serve a proxy.pac file for testing *.localhost wildcard domains

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -88,6 +88,12 @@ export default class UnboxApp {
                 // Show the list of files
                 ctx.body = templates.wrapper(templates.list(file_path, hash.toString(36), details.contents), `${path.basename(file_path)} - `)
                 return
+            } else if (request_path === '/proxy.pac') {
+                // serve a proxy.pac file for testing *.localhost wildcard domains
+                ctx.status = 200
+                ctx.type = 'application/x-ns-proxy-autoconfig'
+                ctx.body = `function FindProxyForURL(url, host) { if (shExpMatch(host, "*localhost")) { return "PROXY localhost:80" } return "DIRECT" }`
+                return
             }
 
             // Trying to load a file from a zip


### PR DESCRIPTION
On macOS, if I go to System Preferences --> Network --> Advanced --> Proxies --> Automatic Proxy Configuration and set the "URL" to be `http://localhost/proxy.pac` I can open `http://asdf.localhost` in Chrome, Safari, and Firefox.

On Windows 10, you can go to Settings --> Network & Internet --> Proxy. Set `http://localhost/proxy.pac` as your "setup script."

Firefox allows you to manually set a proxy on any OS, in Network Settings --> Automatic Proxy Configuration URL. (Of course, that only affects Firefox.)