### PR TITLE
Return status code 300 Multiple Choice when find has multiple candidates

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -153,6 +153,7 @@ export default class UnboxApp {
             if (query.find) {
                 const candidates = details.contents.filter(file => file.endsWith(query.find))
                 if (candidates.length > 1) {
+                    ctx.status = 300
                     ctx.body = templates.wrapper({
                         canonical: `//${this.options.domain}/?url=https://if-archive.org/if-archive/${file_path}&find=${query.find}`,
                         content: templates.list(`Files matching ${query.find} in`, file_path, hash.toString(36), candidates, this.options.domain, this.options.subdomains),


### PR DESCRIPTION
This differentiates it from status code 200 when it returns content directly

https://developer.mozilla.org/en-US/docs/Web/HTTP/Status/300

> The HTTP `300 Multiple Choices` redirect status response code indicates that the request has more than one possible responses. The user-agent or the user should choose one of them. As there is no standardized way of choosing one of the responses, this response code is very rarely used.