### PR TITLE
Small fixes

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -21,7 +21,7 @@ import {
 import * as templates from './templates.js'
 
 const PATH_PARTS = /^\/([0-9a-zA-Z]+)\/?(.*)$/
-const VALID_ORIGINS = /^https?:\/\/(mirror\.|www\.)?ifarchive\.org\//
+const VALID_ORIGINS = /^(https?:\/\/(mirror\.|www\.)?ifarchive\.org)?\//
 
 export default class UnboxApp {
     constructor(options, cache, index) {

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -167,6 +167,10 @@ export default class UnboxApp {
                 ctx.throw(400, `Unknown file: ${query.url}`)
             }
 
+            if (this.index.blocked_files.has(hash)) {
+                ctx.throw(400, `Cannot handle file: ${query.url}`)
+            }
+
             const details = await this.cache.get(hash)
 
             // Open (redirect) to a specific file

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -139,7 +139,15 @@ export default class UnboxApp {
                 ctx.throw(400, `Sorry, we don't support files from outside the IF Archive`)
             }
 
-            let file_path = url.replace(VALID_ORIGINS, '').substring(11)
+            // Remove the "http://domain/" part
+            let uri = url.replace(VALID_ORIGINS, '')
+            
+            if (!uri.startsWith('if-archive/')) {
+                ctx.throw(400, `Sorry, we don't support files outside the if-archive tree`)
+            }
+            
+            // Remove "if-archive/" part
+            let file_path = uri.substring(11)
 
             // Handle symlinks
             if (this.index.symlinked_files.has(file_path)) {

--- a/app/src/archive-index.js
+++ b/app/src/archive-index.js
@@ -18,6 +18,8 @@ import {SUPPORTED_FORMATS} from './common.js'
 import fetch from 'node-fetch'
 import flow from 'xml-flow'
 
+const JSON_VERSION = 3
+
 export default class ArchiveIndex {
     constructor(data_dir, options, cache) {
         this.cache = cache
@@ -64,7 +66,7 @@ export default class ArchiveIndex {
             }
             // Parse the stored data if we didn't update it just now
             const index_data = JSON.parse(await fs.readFile(this.data_path, {encoding: 'utf8'}))
-            if (index_data.symlinks) {
+            if (index_data.version === JSON_VERSION) {
                 console.log('ArchiveIndex: Loading stored data')
                 await this.update_maps(index_data)
                 return
@@ -140,8 +142,9 @@ export default class ArchiveIndex {
 
             xml.on('end', () => resolve({
                 files,
-                symlinks,
                 meta_blocks,
+                symlinks,
+                version: JSON_VERSION,
             }))
         })
     }

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -72,7 +72,7 @@ export default class FileCache {
         // Download the file with curl
         const url = `https://${this.options.archive_domain}/if-archive/${this.index.hash_to_path.get(hash)}`
         const type = SUPPORTED_FORMATS.exec(url)[1].toLowerCase()
-        const cache_path = path.join(this.cache_dir, `${hash.toString(36)}.${type}`)
+        const cache_path = this.file_path(hash, type)
         const details = await execFile('curl', [encodeURI(url), '-o', cache_path, '-s', '-S', '-D', '-'])
         if (details.stderr) {
             throw new Error(`curl error: ${details.stderr}`)

--- a/app/src/common.js
+++ b/app/src/common.js
@@ -31,6 +31,8 @@ export const COMMON_FILE_TYPES = {
     z3: 'application/x-zmachine',
     z4: 'application/x-zmachine',
     z5: 'application/x-zmachine',
+    z6: 'application/x-zmachine',
+    z7: 'application/x-zmachine',
     z8: 'application/x-zmachine',
 }
 


### PR DESCRIPTION
Miscellaneous fixes.

- Supported the "block this file" idea. This is handled by adding a metadata key in Master-Index with key `unbox-block` and value `true`. The archive-index.js module watches for this key and adds the hash to index.blocked_files. Then we refuse to serve that hash.
- Accept URLs with no domain name. That is, you can enter a URL of the form "/if-archive/..."
- A bit more safety-checking when accepting URLs. (The post-domain path must begin with "if-archive/".)
- Changed a path.join() call in cache.js to call this.file_path(). (Same functionality.)
- Added z6, z7 to the COMMON_FILE_TYPES list.

This PR should merge ok with my comments PR, but I haven't checked that.
