### PR TITLE
Support for .tar.Z files

### DIFF
--- a/app/Dockerfile
+++ b/app/Dockerfile
@@ -1,7 +1,7 @@
 FROM ubuntu:20.04
 
 RUN apt-get update && \
-    apt-get install -y curl locales unzip && \
+    apt-get install -y curl locales unzip ncompress && \
     curl -fsSL https://deb.nodesource.com/setup_16.x | bash - && \
     apt-get install -y nodejs && \
     rm -rf /var/lib/apt/lists/* && \

--- a/app/src/archive-index.js
+++ b/app/src/archive-index.js
@@ -22,7 +22,7 @@ import {SUPPORTED_FORMATS} from './common.js'
 import fetch from 'node-fetch'
 import flow from 'xml-flow'
 
-const JSON_VERSION = 4
+const JSON_VERSION = 5
 
 export default class ArchiveIndex {
     constructor(data_dir, options, cache) {

--- a/app/src/common.js
+++ b/app/src/common.js
@@ -38,7 +38,7 @@ export const COMMON_FILE_TYPES = {
 }
 
 // Regex: what package formats do we handle?
-export const SUPPORTED_FORMATS = /\.(tar\.gz|tgz|zip)$/i
+export const SUPPORTED_FORMATS = /\.(tar\.gz|tgz|tar\.z|zip)$/i
 
 // List of types where we need to do additional work to get the character set headers right.
 export const TYPES_TO_DETECT_BETTER = [

--- a/doc/spec.md
+++ b/doc/spec.md
@@ -1,6 +1,6 @@
 ## What Unbox does
 
-The front page ([https://unbox.ifarchive.org/][Unbox]) requests an Archive URL or path. This must be the URL of a `zip`, `tar.gz`, or `.tgz` on the IF Archive. (`http:` and `https:` URLs are both accepted, since they give the same result. You may also omit the domain and enter an absolute path URI, beginning with a slash.)
+The front page ([https://unbox.ifarchive.org/][Unbox]) requests an Archive URL or path. This must be the URL of a `zip`, `tar.gz`, `tgz`, or `tar.Z` on the IF Archive. (`http:` and `https:` URLs are both accepted, since they give the same result. You may also omit the domain and enter an absolute path URI, beginning with a slash.)
 
 [ifarch]: https://ifarchive.org/
 [iplayif]: https://iplayif.com/
@@ -82,7 +82,7 @@ When JSON mode is requested the app will return a JSON file for lists, searches,
 
 In production, Unbox consists of three layers:
 
-- `ifarchive-unbox` is the app itself. It maintains a cache of `zip/tgz/tar.gz` files downloaded from [ifarchive.org][ifarch]. It also keeps a local copy of the Archive's `Master-Index.xml` file.
+- `ifarchive-unbox` is the app itself. It maintains a cache of `zip/tgz/tar.gz/tar.Z` files downloaded from [ifarchive.org][ifarch]. It also keeps a local copy of the Archive's `Master-Index.xml` file.
 - `nginx` is a caching web server that runs in front of `ifarchive-unbox`. This caches HTML/SVG files.
 - A CDN such as CloudFlare is configured in front of `nginx`. This handles caching of media files.
 


### PR DESCRIPTION
Looks like `tar -tf` auto-figures-out the compression? We could make those commands `-tzf` and `-tZf`, I suppose.
