### PR TITLE
Use the base36 string as the hash key instead of int

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -182,7 +182,7 @@ export default class UnboxApp {
                 }
                 if (results.length === 1) {
                     ctx.status = 301
-                    ctx.redirect(`/${hash.toString(36)}/${results[0]}`)
+                    ctx.redirect(`/${hash}/${results[0]}`)
                     return
                 }
                 // No matching file, but if enabled we can look for another file of the same type
@@ -191,7 +191,7 @@ export default class UnboxApp {
                     const results = details.contents.filter(file => same_type_regexp.test(file))
                     if (results.length === 1) {
                         ctx.status = 301
-                        ctx.redirect(`/${hash.toString(36)}/${results[0]}`)
+                        ctx.redirect(`/${hash}/${results[0]}`)
                         return
                     }
                 }
@@ -213,7 +213,7 @@ export default class UnboxApp {
                 if ('json' in query) {
                     ctx.body = {
                         files: results,
-                        hash: hash.toString(36),
+                        hash: hash,
                     }
                 }
                 else {
@@ -223,7 +223,7 @@ export default class UnboxApp {
                             alllink: true,
                             domain: this.options.domain,
                             files: results,
-                            hash: hash.toString(36),
+                            hash: hash,
                             label: `Files matching ${query.search} in`,
                             path: file_path,
                             subdomains: this.options.subdomains,
@@ -238,7 +238,7 @@ export default class UnboxApp {
             if ('json' in query) {
                 ctx.body = {
                     files: details.contents,
-                    hash: hash.toString(36),
+                    hash: hash,
                 }
                 return
             }
@@ -262,7 +262,7 @@ export default class UnboxApp {
                 content: templates.list({
                     domain: this.options.domain,
                     files: details.contents,
-                    hash: hash.toString(36),
+                    hash: hash,
                     label: 'Contents of',
                     path: file_path,
                     starthtml,
@@ -278,11 +278,11 @@ export default class UnboxApp {
         if (!path_parts) {
             ctx.throw(400, 'This is not a valid file')
         }
-        const hash_string = path_parts[1]
-        const hash = parseInt(hash_string, 36)
+        const hash = path_parts[1]
+        // We could validate the hash format here, but only valid hashes are in index.hash_to_path.
         const zip_path = this.index.hash_to_path.get(hash)
         if (!zip_path) {
-            ctx.throw(404, `Unknown file hash: ${hash_string}`)
+            ctx.throw(404, `Unknown file hash: ${hash}`)
         }
 
         // Redirect folder views back to the index
@@ -299,7 +299,7 @@ export default class UnboxApp {
         }
 
         // Check for non-matching subdomain
-        if (this.options.subdomains && UNSAFE_FILES.test(file_path) && !ctx.hostname.startsWith(hash_string)) {
+        if (this.options.subdomains && UNSAFE_FILES.test(file_path) && !ctx.hostname.startsWith(hash)) {
             ctx.throw(400, `Incorrect subdomain`)
         }
 

--- a/app/src/archive-index.js
+++ b/app/src/archive-index.js
@@ -22,7 +22,7 @@ import {SUPPORTED_FORMATS} from './common.js'
 import fetch from 'node-fetch'
 import flow from 'xml-flow'
 
-const JSON_VERSION = 5
+const JSON_VERSION = 6
 
 export default class ArchiveIndex {
     constructor(data_dir, options, cache) {
@@ -126,7 +126,8 @@ export default class ArchiveIndex {
                 // Regular files
                 else if (SUPPORTED_FORMATS.test(path)) {
                     // 48 bits of the sha512 hash of the path
-                    const hash = parseInt(crypto.createHash('sha512').update(path).digest('hex').substring(0, 12), 16)
+                    let hash = parseInt(crypto.createHash('sha512').update(path).digest('hex').substring(0, 12), 16)
+                    hash = hash.toString(36).padStart(10, '0')
                     const date = +(new Date(`${file.date} UTC`))
                     files.push([hash, path, date])
 

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -65,6 +65,8 @@ export default class FileCache {
             this.lru.push(hash)
             this.size += size
         }))
+
+        console.log(`Cache initialized with ${this.lru.length} entries, ${this.size} bytes total`)
     }
 
     // Download and set up a cache entry
@@ -131,6 +133,8 @@ export default class FileCache {
             this.hit(hash)
             return this.cache.get(hash)
         }
+
+        console.log(`Downloading cache entry ${hash} (${this.index.hash_to_path.get(hash)})`)
 
         // We add the promise to the cache even if it's pending. That way, future callers will get the same promise and will wait in parallel on it.
         // (It would be bad if two callers got different promises to the same hash, which then started to download to the same location.)

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -54,7 +54,7 @@ export default class FileCache {
         await Promise.all(files.map(async file => {
             const file_path = path.join(this.cache_dir, file)
             const parts = /(\w+)\.(.+)/.exec(file)
-            const hash = parseInt(parts[1], 36)
+            const hash = parts[1]
             const stat = await fs.stat(file_path)
             const date = +stat.mtime
             const size = stat.size
@@ -121,7 +121,7 @@ export default class FileCache {
     // Return the path where the given Archive file is downloaded to.
     // (HASH.zip, HASH.tar.gz, etc in the cache dir.)
     file_path(hash, type) {
-        return path.join(this.cache_dir, `${hash.toString(36)}.${type}`)
+        return path.join(this.cache_dir, `${hash}.${type}`)
     }
 
     // Get a file out of the cache, or download it
@@ -256,7 +256,7 @@ export default class FileCache {
         for (const [hash, entry] of this.cache) {
             if (entry instanceof CacheEntry && entry.date !== data.get(hash))
             {
-                console.log(`Removing outdated cache file ${hash.toString(36)}.${entry.type} (${this.index.hash_to_path.get(hash)})`)
+                console.log(`Removing outdated cache file ${hash}.${entry.type} (${this.index.hash_to_path.get(hash)})`)
                 this.cache.delete(hash)
                 const oldpos = this.lru.indexOf(hash)
                 this.lru.splice(oldpos, 1)


### PR DESCRIPTION
This tidies up a lot of "toString(36)" calls and makes everything easier to read.

I've also ensured that the hash string is exactly 10 chars. 

Also added a couple of log lines to improve visibility.
