### PR TITLE
Configure the "local" logdriver

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,6 +3,8 @@ services:
     build: ./app
     environment:
       DATA_DIR: /home/data
+    logging:
+      driver: local
     restart: always
     volumes:
       - ./data:/home/data
@@ -11,6 +13,8 @@ services:
     build: ./certbot
     environment:
       DATA_DIR: /home/data
+    logging:
+      driver: local
     volumes:
       - ./data:/home/data
       - ./data/certbot:/etc/letsencrypt
@@ -19,6 +23,8 @@ services:
     build: ./nginx
     environment:
       DATA_DIR: /home/data
+    logging:
+      driver: local
     ports:
       - "80:80"
       - "443:443"


### PR DESCRIPTION
I think this is the right way to do this. 

According to https://docs.docker.com/config/containers/logging/local/, the default is to keep 5 log files of up to 20 megabytes each. Seems reasonable.

Note that `docker info` will still say `Logging Driver: json-file`, because that's the system default. To observe the config for a container, do `docker inspect ifarchive-unbox_app_1` and look at the HostConfig.LogConfig stanza.
