### PR TITLE
Small fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,3 +56,7 @@ If you modify the source code, you must bring the service down and back up to se
 docker-compose down
 docker-compose up --build
 ```
+
+The server is built on the [Koa][] web framework.
+
+[Koa]: https://koajs.com/

--- a/app/src/app.js
+++ b/app/src/app.js
@@ -53,6 +53,8 @@ export default class UnboxApp {
                     })
                 }
                 if (ctx.status < 400 || ctx.status > 404) {
+                    const errdate = new Date()
+                    console.log(`Internal error: (${errdate.toISOString()}): ${ctx.url}`)
                     ctx.app.emit('error', err, ctx)
                 }
             }

--- a/app/src/archive-index.js
+++ b/app/src/archive-index.js
@@ -187,6 +187,8 @@ export default class ArchiveIndex {
             this.blocked_files.add(hash)
         }
 
+        console.log(`ArchiveIndex: found ${this.hash_to_path.size} hash entries, ${this.symlinked_dirs.size} symlinked dirs, ${this.symlinked_files.size} symlinked files, ${this.blocked_files.size} blocked files`)
+
         // Purge the cache of old files
         await this.cache.purge(hash_to_date)
     }

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -59,11 +59,20 @@ export default class FileCache {
             const date = +stat.mtime
             const size = stat.size
             const type = parts[2]
-            const contents = await this.list_contents(file_path, type)
-            const entry = new CacheEntry(contents, date, size, type)
-            this.cache.set(hash, entry)
-            this.lru.push(hash)
-            this.size += size
+            try {
+                const contents = await this.list_contents(file_path, type)
+                const entry = new CacheEntry(contents, date, size, type)
+                this.cache.set(hash, entry)
+                this.lru.push(hash)
+                this.size += size
+            }
+            catch (err) {
+                console.log(`Removing unreadable cache file ${file}: ${err}`)
+                try {
+                    await fs.rm(file_path)
+                }
+                catch (_) {}
+            }
         }))
 
         console.log(`Cache initialized with ${this.lru.length} entries, ${this.size} bytes total`)

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -265,6 +265,7 @@ export default class FileCache {
     }
 
     // Purge out of date files
+    // The argument is a map of hash->timestamp, extracted from the Master-Index we just loaded
     async purge(data) {
         for (const [hash, entry] of this.cache) {
             if (entry instanceof CacheEntry && entry.date !== data.get(hash))


### PR DESCRIPTION
Couple of improvements to diagnostics:

- If we encounter an internal error, we log the timestamp and URL before passing the error up to Koa. 
- After loading Master-Index, log the number of cache entries found.

Also one serious fix. In cache.init(), if a single list_contents() call fails, the whole init() call fails. Then the cache tries to reload forever. Turns out list_contents() fails a lot! (See bug filed separately.)

I've updated cache.init() to catch these failures, log an error, and remove the offending file.
