### PR TITLE
Tolerate warnings from unzip/untar

### DIFF
--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -177,7 +177,7 @@ export default class FileCache {
                 results = await execFile('unzip', ['-p', zip_path, file_path], {encoding: 'buffer', maxBuffer: this.max_buffer})
                 break
             default:
-                throw new Error('Other archive format not yet supported')
+                throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr.length) {
             throw new Error(`${command} error: ${results.stderr.toString()}`)
@@ -201,7 +201,7 @@ export default class FileCache {
                 child = child_process.spawn('unzip', ['-p', zip_path, file_path])
                 break
             default:
-                throw new Error('Other archive format not yet supported')
+                throw new Error(`Archive format ${type} not yet supported`)
         }
         return child.stdout
     }
@@ -225,7 +225,7 @@ export default class FileCache {
                 results = await exec(`unzip -p ${zip_path} '${escape_shell_single_quoted(file_path)}' | file -i -`)
                 break
             default:
-                throw new Error('Other archive format not yet supported')
+                throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr.length) {
             throw new Error(`${command}|file error: ${results.stderr.toString()}`)
@@ -256,7 +256,7 @@ export default class FileCache {
                 results = await execFile('unzip', ['-Z1', path])
                 break
             default:
-                throw new Error('Other archive format not yet supported')
+                throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr) {
             throw new Error(`${command} error: ${results.stderr}`)

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -35,7 +35,7 @@ function untar_error(err) {
     if (err.signal) {
         return { failed:true, stdout:err.stdout, stderr:`SIGNAL ${err.signal}\n${err.stderr}` }
     }
-    if (err.code != 0) {
+    if (err.code !== 0) {
         return { failed:true, stdout:err.stdout, stderr:err.stderr }
     }
     // For certain old tar files, stderr contains an error like "A lone zero block at..." But err.code is zero so we consider it success.
@@ -48,7 +48,7 @@ function unzip_error(err) {
     }
     // Special case: unzip returns status 1 for "unzip succeeded with warnings". (See man page.) We consider this to be a success.
     // We see this with certain zip files and warnings like "128 extra bytes at beginning or within zipfile".
-    if (err.code != 0 && err.code != 1) {
+    if (err.code !== 0 && err.code !== 1) {
         return { failed:true, stdout:err.stdout, stderr:err.stderr }
     }
     return { stdout:err.stdout, stderr:err.stderr }

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -38,7 +38,7 @@ function unzip_error(err) {
     if (err.signal) {
         return { failed:true, stdout:err.stdout, stderr:`SIGNAL ${err.signal}\n${err.stderr}` }
     }
-    if (err.code != 0) {
+    if (err.code != 0 && err.code != 1) {
         return { failed:true, stdout:err.stdout, stderr:err.stderr }
     }
     return { stdout:err.stdout, stderr:err.stderr }

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -200,10 +200,10 @@ export default class FileCache {
                 throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr.length) {
-            console.log(`${command} error: ${results.stderr.toString()}`)
+            console.log(`${file_path}: ${command} error: ${results.stderr.toString()}`)
         }
         if (results.failed) {
-            throw new Error(`${command} error: ${results.stderr.toString()}`)
+            throw new Error(`${file_path}: ${command} error: ${results.stderr.toString()}`)
         }
         return results.stdout
     }
@@ -251,10 +251,10 @@ export default class FileCache {
                 throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr.length) {
-            console.log(`${command} error: ${results.stderr.toString()}`)
+            console.log(`${file_path}: ${command} error: ${results.stderr.toString()}`)
         }
         if (results.failed) {
-            throw new Error(`${command}|file error: ${results.stderr.toString()}`)
+            throw new Error(`${file_path}: ${command}|file error: ${results.stderr.toString()}`)
         }
         // Trim '/dev/stdin:'
         return results.stdout.trim().substring(12)
@@ -285,10 +285,10 @@ export default class FileCache {
                 throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr) {
-            console.log(`${command} error: ${results.stderr.toString()}`)
+            console.log(`${path}: ${command} error: ${results.stderr.toString()}`)
         }
         if (results.failed) {
-            throw new Error(`${command} error: ${results.stderr}`)
+            throw new Error(`${path}: ${command} error: ${results.stderr}`)
         }
         return results.stdout.trim().split('\n').filter(line => !line.endsWith('/')).sort()
     }

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -84,13 +84,13 @@ export default class FileCache {
         const url = `https://${this.options.archive_domain}/if-archive/${this.index.hash_to_path.get(hash)}`
         const type = SUPPORTED_FORMATS.exec(url)[1].toLowerCase()
         const cache_path = this.file_path(hash, type)
-        const details = await execFile('curl', [encodeURI(url), '-o', cache_path, '-s', '-S', '-D', '-'])
-        if (details.stderr) {
-            throw new Error(`curl error: ${details.stderr}`)
+        const results = await execFile('curl', [encodeURI(url), '-o', cache_path, '-s', '-S', '-D', '-'])
+        if (results.stderr) {
+            throw new Error(`curl error: ${results.stderr}`)
         }
 
         // Parse the date
-        const date_header = /last-modified:\s+\w+,\s+(\d+\s+\w+\s+\d+)/.exec(details.stdout)
+        const date_header = /last-modified:\s+\w+,\s+(\d+\s+\w+\s+\d+)/.exec(results.stdout)
         if (!date_header) {
             throw new Error('Could not parse last-modified header')
         }

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -46,7 +46,7 @@ function unzip_error(err) {
     if (err.signal) {
         return { failed:true, stdout:err.stdout, stderr:`SIGNAL ${err.signal}\n${err.stderr}` }
     }
-    // Special case: unzip return status 1 for "unzip succeeded with warnings". (See man page.) We consider this to be a success.
+    // Special case: unzip returns status 1 for "unzip succeeded with warnings". (See man page.) We consider this to be a success.
     // We see this with certain zip files and warnings like "128 extra bytes at beginning or within zipfile".
     if (err.code != 0 && err.code != 1) {
         return { failed:true, stdout:err.stdout, stderr:err.stderr }


### PR DESCRIPTION
See https://github.com/iftechfoundation/ifarchive-unbox/issues/38 .

This changes the process handling for unzip/untar so that we only fail if the error status is nonzero. (For unzip, we fail on anything other than zero or one.) Stderr output is logged but does not cause a failure.
