### PR TITLE
Don't use exec() for file

### DIFF
--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -92,7 +92,7 @@ function spawn_pipe_file_cb(command, args, callback) {
     })
 
     // Ignore errors sending data to file stdin. (It likes to close its input, which results in an EPIPE error.)
-    fileproc.stdin.on('error', _ => {})
+    fileproc.stdin.on('error', () => {})
     // Add stdout and stderr to our accumulators.
     fileproc.stdout.on('data', data => { stdout += data })
     fileproc.stderr.on('data', data => { stderr += data })

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -21,7 +21,6 @@ import util from 'util'
 
 import {SUPPORTED_FORMATS} from './common.js'
 
-const exec = util.promisify(child_process.exec)
 const execFile = util.promisify(child_process.execFile)
 
 /* Promise-rejection handlers for untar/unzip. These return objects of the
@@ -93,7 +92,7 @@ function spawn_pipe_file_cb(command, args, callback) {
     })
 
     // Ignore errors sending data to file stdin. (It likes to close its input, which results in an EPIPE error.)
-    fileproc.stdin.on('error', data => {})
+    fileproc.stdin.on('error', _ => {})
     // Add stdout and stderr to our accumulators.
     fileproc.stdout.on('data', data => { stdout += data })
     fileproc.stderr.on('data', data => { stderr += data })

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -19,7 +19,7 @@ import fs from 'fs/promises'
 import path from 'path'
 import util from 'util'
 
-import {SUPPORTED_FORMATS, escape_shell_single_quoted} from './common.js'
+import {SUPPORTED_FORMATS} from './common.js'
 
 const exec = util.promisify(child_process.exec)
 const execFile = util.promisify(child_process.execFile)

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -177,7 +177,7 @@ export default class FileCache {
                 results = await execFile('unzip', ['-p', zip_path, file_path], {encoding: 'buffer', maxBuffer: this.max_buffer})
                 break
             default:
-                throw new Error('Other archive format not yet supported')
+                throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr.length) {
             throw new Error(`${command} error: ${results.stderr.toString()}`)
@@ -201,7 +201,7 @@ export default class FileCache {
                 child = child_process.spawn('unzip', ['-p', zip_path, file_path])
                 break
             default:
-                throw new Error('Other archive format not yet supported')
+                throw new Error(`Archive format ${type} not yet supported`)
         }
         return child.stdout
     }
@@ -225,7 +225,7 @@ export default class FileCache {
                 results = await exec(`unzip -p ${zip_path} '${escape_shell_single_quoted(file_path)}' | file -i -`)
                 break
             default:
-                throw new Error('Other archive format not yet supported')
+                throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr.length) {
             throw new Error(`${command}|file error: ${results.stderr.toString()}`)
@@ -256,7 +256,7 @@ export default class FileCache {
                 results = await execFile('unzip', ['-Z1', path])
                 break
             default:
-                throw new Error('Other archive format not yet supported')
+                throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr) {
             throw new Error(`${command} error: ${results.stderr}`)

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -80,14 +80,14 @@ function spawn_pipe_file_cb(command, args, callback) {
     let uncode = null
 
     // Send unzip stdout to file stdin
-    unproc.stdout.on('data', data => { fileproc.stdin.write(data); })
+    unproc.stdout.on('data', data => { fileproc.stdin.write(data) })
     // Add stderr to our accumulator.
-    unproc.stderr.on('data', data => { stderr += data; })
+    unproc.stderr.on('data', data => { stderr += data })
     unproc.on('close', code => {
         // Record the status code of the unzip process
         uncode = code
         // Again, unzip code 1 is okay
-        if (command == 'unzip' && code == 1)
+        if (command === 'unzip' && code === 1)
             uncode = 0
         fileproc.stdin.end()
     })
@@ -95,8 +95,8 @@ function spawn_pipe_file_cb(command, args, callback) {
     // Ignore errors sending data to file stdin. (It likes to close its input, which results in an EPIPE error.)
     fileproc.stdin.on('error', data => {})
     // Add stdout and stderr to our accumulators.
-    fileproc.stdout.on('data', data => { stdout += data; })
-    fileproc.stderr.on('data', data => { stderr += data; })
+    fileproc.stdout.on('data', data => { stdout += data })
+    fileproc.stderr.on('data', data => { stderr += data })
     
     fileproc.on('close', code => {
         // All done; call the callback. Fill in the first argument for failure, second arguent for success.
@@ -305,15 +305,15 @@ export default class FileCache {
             case 'tar.gz':
             case 'tgz':
                 command = 'tar|file'
-                results = await spawn_pipe_file('tar', ['-xOzf', zip_path, file_path]).catch(err => { return err; })
+                results = await spawn_pipe_file('tar', ['-xOzf', zip_path, file_path]).catch(err => { return err })
                 break
             case 'tar.z':
                 command = 'tar|file'
-                results = await spawn_pipe_file('tar', ['-xOZf', zip_path, file_path]).catch(err => { return err; })
+                results = await spawn_pipe_file('tar', ['-xOZf', zip_path, file_path]).catch(err => { return err })
                 break
             case 'zip':
                 command = 'unzip|file'
-                results = await spawn_pipe_file('unzip', ['-p', zip_path, file_path]).catch(err => { return err; })
+                results = await spawn_pipe_file('unzip', ['-p', zip_path, file_path]).catch(err => { return err })
                 break
             default:
                 throw new Error(`Archive format ${type} not yet supported`)

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -54,7 +54,7 @@ function unzip_error(err) {
     return { stdout:err.stdout, stderr:err.stderr }
 }
 
-async function spawn_pipe_file_cb(command, args, callback) {
+function spawn_pipe_file_cb(command, args, callback) {
     const unproc = child_process.spawn(command, args)
     const fileproc = child_process.spawn('file', ['-i', '-'])
 

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -38,7 +38,7 @@ function unzip_error(err) {
     if (err.signal) {
         return { failed:true, stdout:err.stdout, stderr:`SIGNAL ${err.signal}\n${err.stderr}` }
     }
-    if (err.code != 0) {
+    if (err.code != 0 && err.code != 1) {
         return { failed:true, stdout:err.stdout, stderr:err.stderr }
     }
     return { stdout:err.stdout, stderr:err.stderr }

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -200,10 +200,10 @@ export default class FileCache {
                 throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr.length) {
-            console.log(`${command} error: ${results.stderr.toString()}`)
+            console.log(`${file_path}: ${command} error: ${results.stderr.toString()}`)
         }
         if (results.failed) {
-            throw new Error(`${command} error: ${results.stderr.toString()}`)
+            throw new Error(`${file_path}: ${command} error: ${results.stderr.toString()}`)
         }
         return results.stdout
     }
@@ -251,10 +251,10 @@ export default class FileCache {
                 throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr.length) {
-            console.log(`${command} error: ${results.stderr.toString()}`)
+            console.log(`${file_path}: ${command} error: ${results.stderr.toString()}`)
         }
         if (results.failed) {
-            throw new Error(`${command}|file error: ${results.stderr.toString()}`)
+            throw new Error(`${file_path}: ${command}|file error: ${results.stderr.toString()}`)
         }
         // Trim '/dev/stdin:'
         return results.stdout.trim().substring(12)
@@ -285,10 +285,10 @@ export default class FileCache {
                 throw new Error(`Archive format ${type} not yet supported`)
         }
         if (results.stderr) {
-            console.log(`${command} error: ${results.stderr.toString()}`)
+            console.log(`${path}: ${command} error: ${results.stderr.toString()}`)
         }
         if (results.failed) {
-            throw new Error(`${command} error: ${results.stderr}`)
+            throw new Error(`${path}: ${command} error: ${results.stderr}`)
         }
         return results.stdout.trim().split('\n').filter(line => !line.endsWith('/')).sort()
     }

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -84,13 +84,13 @@ export default class FileCache {
         const url = `https://${this.options.archive_domain}/if-archive/${this.index.hash_to_path.get(hash)}`
         const type = SUPPORTED_FORMATS.exec(url)[1].toLowerCase()
         const cache_path = this.file_path(hash, type)
-        const details = await execFile('curl', [encodeURI(url), '-o', cache_path, '-s', '-S', '-D', '-'])
-        if (details.stderr) {
-            throw new Error(`curl error: ${details.stderr}`)
+        const results = await execFile('curl', [encodeURI(url), '-o', cache_path, '-s', '-S', '-D', '-'])
+        if (results.stderr) {
+            throw new Error(`curl error: ${results.stderr}`)
         }
 
         // Parse the date
-        const date_header = /last-modified:\s+\w+,\s+(\d+\s+\w+\s+\d+)/.exec(details.stdout)
+        const date_header = /last-modified:\s+\w+,\s+(\d+\s+\w+\s+\d+)/.exec(results.stdout)
         if (!date_header) {
             throw new Error('Could not parse last-modified header')
         }

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -67,6 +67,9 @@ async function spawn_pipe_file_cb(command, args, callback) {
     unproc.stderr.on('data', data => { stderr += data; })
     unproc.on('close', code => {
         uncode = code
+	// Again, unzip code 1 is okay
+	if (command == 'unzip' && code == 1)
+	    uncode = 0
         fileproc.stdin.end()
     })
 

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -55,8 +55,8 @@ function unzip_error(err) {
 }
 
 async function spawn_pipe_file_cb(command, args, callback) {
-    const unproc = spawn(command, args)
-    const fileproc = spawn('file', ['-i', '-'])
+    const unproc = child_process.spawn(command, args)
+    const fileproc = child_process.spawn('file', ['-i', '-'])
 
     let stdout = ''
     let stderr = ''

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -46,7 +46,7 @@ function unzip_error(err) {
     if (err.signal) {
         return { failed:true, stdout:err.stdout, stderr:`SIGNAL ${err.signal}\n${err.stderr}` }
     }
-    // Special case: unzip return status 1 for "unzip succeeded with warnings". (See man page.) We consider this to be a success.
+    // Special case: unzip returns status 1 for "unzip succeeded with warnings". (See man page.) We consider this to be a success.
     // We see this with certain zip files and warnings like "128 extra bytes at beginning or within zipfile".
     if (err.code != 0 && err.code != 1) {
         return { failed:true, stdout:err.stdout, stderr:err.stderr }

--- a/app/src/cache.js
+++ b/app/src/cache.js
@@ -67,9 +67,9 @@ async function spawn_pipe_file_cb(command, args, callback) {
     unproc.stderr.on('data', data => { stderr += data; })
     unproc.on('close', code => {
         uncode = code
-	// Again, unzip code 1 is okay
-	if (command == 'unzip' && code == 1)
-	    uncode = 0
+        // Again, unzip code 1 is okay
+        if (command == 'unzip' && code == 1)
+            uncode = 0
         fileproc.stdin.end()
     })
 

--- a/app/src/common.js
+++ b/app/src/common.js
@@ -57,7 +57,3 @@ export function escape_regexp(str) {
     return str.replace(/[.*+?^${}()|[\]\\]/g, '\\$&') // $& means the whole matched string
 }
 
-// Escape for use inside of a single quoted shell argument
-export function escape_shell_single_quoted(str) {
-    return str.replace(/'/g, `'\\''`)
-}


### PR DESCRIPTION
Note: This PR is built on top of https://github.com/iftechfoundation/ifarchive-unbox/pull/41 ! Merge that first.

I've written a little utility to pipe the output of unzip/untar into file.

This uses the Node event-driven file-stream API. All the output of `unzip -p xxx.zip file` goes through the unbox process. But we don't store it all, not even in memory. It's just passed along chunk by chunk.

(The stdout/stderr output of file *does* get accumulated in memory. But that's tiny.)

Now, the bad news: this doesn't fix the problems that I originally thought it would fix. In https://github.com/iftechfoundation/ifarchive-unbox/issues/39 , I mentioned two files causing errors:

- [/if-archive/infocom/compilers/inform6/library/contributions/platypus.zip][ctrlmbug] (see `Icon^M` etc)
- [/if-archive/games/mini-comps/adrift/onehourcomp4.zip][bracketbug] (see `agent_4F[1].A.taf`)

[ctrlmbug]: https://unbox.ifarchive.org/?url=%2Fif-archive%2Finfocom%2Fcompilers%2Finform6%2Flibrary%2Fcontributions%2Fplatypus.zip
[bracketbug]: https://unbox.ifarchive.org/?url=%2Fif-archive%2Fgames%2Fmini-comps%2Fadrift%2Fonehourcomp4.zip

Turns out these are not shell bugs. They are mismatches between what unzip reports in its file list and what it accepts as a filename. Oh well! 

(I recognize the `Icon^M` thing. It's a MacOS Classic convention where a folder icon appeared in the filesystem with that filename, yes, with a ctrl-M in it. Everybody hated that.)

Anyhow, this spurred me into cleaning up the exec() situation, and I'm very happy about that. I think my implementation is correct. It's possible I missed something; I still haven't spent a lot of time in async-node-land.

