### PR TITLE
Allow safe files on subdomains. Fixes #61

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -77,13 +77,6 @@ export default class UnboxApp {
                     ctx.throw(400, 'Too many subdomains')
                 }
 
-                // Safe file on non-subdomain
-                if (subdomain_count === 1 && !UNSAFE_FILES.test(path)) {
-                    ctx.status = 301
-                    ctx.redirect(`//${domain}${path}`)
-                    return
-                }
-
                 // Unsafe file on main domain
                 if (subdomain_count === 0 && UNSAFE_FILES.test(path)) {
                     const path_parts = PATH_PARTS.exec(path)


### PR DESCRIPTION
In https://github.com/iftechfoundation/ifarchive-unbox/commit/170844e13c6726f07dcb71ab8b54bfd2a51cf61a @curiousdannii wrote, "Redirect to subdomain for unsafe file and vice versa."

But we don't need to redirect to the non-subdomain for safe files; we can just serve the safe files on the subdomain, too. This fixes #61 and is simpler all around.