### PR TITLE
Allow safe files on certain subdomains

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -25,6 +25,13 @@ import * as templates from './templates.js'
 const PATH_PARTS = /^\/([0-9a-zA-Z]+)\/?(.*)$/
 const VALID_ORIGINS = /^(https?:\/\/(mirror\.|www\.)?ifarchive\.org)?\//
 
+// https://github.com/iftechfoundation/ifarchive-unbox/issues/61
+// When adding subdomains to this list, we need to manually add them in the Cloudflare admin tool
+const ALLOWED_SUBDOMAINS = new Set([
+    // /if-archive/games/competition2024/Games/Quest_for_the_Teacup_of_Minor_Sentimental_Value.zip
+    '2k788xeots',
+])
+
 export default class UnboxApp {
     constructor(options, cache, index) {
         this.cache = cache
@@ -78,7 +85,7 @@ export default class UnboxApp {
                 }
 
                 // Safe file on non-subdomain
-                if (subdomain_count === 1 && !UNSAFE_FILES.test(path)) {
+                if (subdomain_count === 1 && !UNSAFE_FILES.test(path) && !ALLOWED_SUBDOMAINS.has(ctx.subdomains[0])) {
                     ctx.status = 301
                     ctx.redirect(`//${domain}${path}`)
                     return


### PR DESCRIPTION
Fixes #61

In #62, I wrote a PR to allow safe files on _all_ subdomains, but @erkyrath pointed out the problem with that:
> Safe files are redirected to the main domain because the main domain is CDNified (Cloudflare). The effect of this change is to move all the server load of media files -- the big ones -- from Cloudflare to Unbox.

Here, I've taken a different approach. Don't allow safe files on all subdomains, but just on a set of allow-listed subdomains (currently, just the only game that's triggering #61, but, in the future, we could add more.)

Every time we hit a bug like #61, we'd manually add the subdomain to the allow list. And then, we'd go to the Cloudflare admin tool and explicitly enable Cloudflare proxying for that subdomain.

I'm not anticipating that there would be very many of these. (We've only encountered one so far… I'd be surprised if we needed to do more than one a year for the next 10+ years.)

If we don't implement it this way, there is a one-line workaround possible by modifying the game code, described here: https://github.com/iftechfoundation/ifarchive-unbox/issues/61#issuecomment-2332486969