### PR TITLE
Set max-age=0 for all resources, except those with `lastmod` parameter

### DIFF
--- a/app/src/app.js
+++ b/app/src/app.js
@@ -72,39 +72,6 @@ export default class UnboxApp {
             }
         })
 
-        // Redirect to subdomains
-        if (options.subdomains) {
-            this.app.subdomainOffset = domain.split('.').length
-            this.app.use(async (ctx, next) => {
-                const path = ctx.path
-                const subdomain_count = ctx.subdomains.length
-
-                // Too many subdomains
-                if (subdomain_count > 1) {
-                    ctx.throw(400, 'Too many subdomains')
-                }
-
-                // Safe file on non-subdomain
-                if (subdomain_count === 1 && !UNSAFE_FILES.test(path) && !ALLOWED_SUBDOMAINS.has(ctx.subdomains[0])) {
-                    ctx.status = 301
-                    ctx.redirect(`//${domain}${path}`)
-                    return
-                }
-
-                // Unsafe file on main domain
-                if (subdomain_count === 0 && UNSAFE_FILES.test(path)) {
-                    const path_parts = PATH_PARTS.exec(path)
-                    if (path_parts) {
-                        ctx.status = 301
-                        ctx.redirect(`//${path_parts[1]}.${domain}${path}`)
-                        return
-                    }
-                }
-
-                await next()
-            })
-        }
-
         // Serve a proxy.pac file
         if (domain && options.serve_proxy_pac) {
             this.app.use(async (ctx, next) => {

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -25,7 +25,7 @@ const default_options = {
         max_size: 1000000000, // 1 GB
     },
     'cache-control-age': 604800, // 1 week
-    'cache-control-age-error': 86400, // 1 day
+    'cache-control-age-error': 0,
     //domain: 'unbox.ifarchive.org', // App domain
     index: {
         index_url: 'https://ifarchive.org/indexes/Master-Index.xml',

--- a/doc/options.json.md
+++ b/doc/options.json.md
@@ -12,7 +12,7 @@ Here are all the options you can set in data/options.json
         "max_size": 1000000000
     },
     "cache-control-age": 604800,
-    "cache-control-age-error": 86400,
+    "cache-control-age-error": 0,
     "certbot": {
         "email": "user@domain.com",
         "renew_time": 720,


### PR DESCRIPTION
Fixes #64.

Setting max-age=0 ensures that we'll always return fresh HTML content.

This won't blow out our bandwidth, because browsers/nginx/Cloudflare will still do conditional `GET` requests, which we'll respond with a cheap, fast "304 Not Modified" response in most cases.

For subresources on on the subdomain, we already redirect them to the main domain, but now, we redirect them with a `?lastmod=###` parameter. URLs with that parameter can have a week-long max-age, because if they change, we'll switch to a different URL.